### PR TITLE
GetStatus() fix in Python example

### DIFF
--- a/sdk/HeliosDac.cpp
+++ b/sdk/HeliosDac.cpp
@@ -95,6 +95,16 @@ int HeliosDac::CloseDevices()
 	return HELIOS_SUCCESS;
 }
 
+int HeliosDac::SetLibusbDebugLogLevel(int logLevel)
+{
+	if (!inited)
+		return HELIOS_ERROR_NOT_INITIALIZED;
+	
+	libusb_set_debug(NULL, logLevel);
+
+	return HELIOS_SUCCESS;
+}
+
 int HeliosDac::WriteFrame(unsigned int devNum, unsigned int pps, std::uint8_t flags, HeliosPoint* points, unsigned int numOfPoints)
 {
 	if (!inited)

--- a/sdk/HeliosDac.h
+++ b/sdk/HeliosDac.h
@@ -122,6 +122,9 @@ public:
 
 	//closes and frees all devices
 	int CloseDevices();
+	
+	//sets debug log level in libusb
+	int SetLibusbDebugLogLevel(int logLevel);
 
 	//writes and outputs a frame to the speficied dac
 	//devNum: dac number (0 to n where n+1 is the return value from OpenDevices() )

--- a/sdk/HeliosDacAPI.cpp
+++ b/sdk/HeliosDacAPI.cpp
@@ -39,6 +39,14 @@ int WriteFrame(unsigned int dacNum, int pps, std::uint8_t flags, HeliosPoint* po
 	return dacController->WriteFrame(dacNum, pps, flags, points, numOfPoints);
 }
 
+int SetLibusbDebugLogLevel(int logLevel)
+{
+	if (!inited)
+		return HELIOS_ERROR_NOT_INITIALIZED;
+
+	return dacController->SetLibusbDebugLogLevel(logLevel);
+}
+
 int Stop(unsigned int dacNum)
 {
 	if (!inited)

--- a/sdk/HeliosDacAPI.h
+++ b/sdk/HeliosDacAPI.h
@@ -56,6 +56,10 @@ HELIOS_EXPORT int OpenDevices();
 //Return 1 if ready to receive new frame, 0 if not, -1 if communcation failed
 HELIOS_EXPORT int GetStatus(unsigned int dacNum);
 
+//Sets libusb debug log level
+//See libusb.h for log level values
+HELIOS_EXPORT int SetLibusbDebugLogLevel(int logLevel);
+
 //writes and outputs a frame to the speficied dac
 //dacNum: dac number (0 to n where n+1 is the return value from OpenDevices() )
 //pps: rate of output in points per second

--- a/sdk/examples/python/linux_example.py
+++ b/sdk/examples/python/linux_example.py
@@ -43,7 +43,7 @@ for i in range(150):
     for j in range(numDevices):
         while (HeliosLib.GetStatus(j) == 0): #Wait for ready status
             pass
-        HeliosLib.WriteFrame(0, 30000, 0, ctypes.pointer(frames[i % 30]), 1000) #Send the frame
+        HeliosLib.WriteFrame(j, 30000, 0, ctypes.pointer(frames[i % 30]), 1000) #Send the frame
 
 
 HeliosLib.CloseDevices()

--- a/sdk/examples/python/linux_example.py
+++ b/sdk/examples/python/linux_example.py
@@ -41,8 +41,10 @@ for i in range(30):
 #Play frames on DAC
 for i in range(150):
     for j in range(numDevices):
-        while (HeliosLib.GetStatus(j) == 0): #Wait for ready status
-            pass
+        statusAttempts = 0
+        # Make 512 attempts for DAC status to be ready. After that, just give up and try to write the frame anyway
+        while (statusAttempts < 512 and HeliosLib.GetStatus(j) != 1):
+            statusAttempts += 1
         HeliosLib.WriteFrame(j, 30000, 0, ctypes.pointer(frames[i % 30]), 1000) #Send the frame
 
 


### PR DESCRIPTION
The Python example was testing for GetStatus() == 0 instead of GetStatus() == 1. This caused timeout errors (which return negative values) to be interpreted as ready status. I changed it to do the same as the C++ example which tries up to 512 times until GetStatus() == 1.