### PR TITLE
Chore : Change doc for ubuntu 20.04 at RPi

### DIFF
--- a/docs/compiling_for_raspberry_pi.md
+++ b/docs/compiling_for_raspberry_pi.md
@@ -10,10 +10,15 @@ sudo apt-get install libusb-1.0-0-dev
 and replace
 libusb-1.0.so by the installed version
 ```shell
-cp /usr/lib/arm-linux-gnueabihf/libusb-1.0.so
-/home/pi/helios_dac/sdk/libusb-1.0.so
+cp /usr/lib/arm-linux-gnueabihf/libusb-1.0.so ./helios_dac/sdk/libusb-1.0.so
+```
+(In case of ubuntu 20.04 with RPi)
+```shell
+cp /usr/lib/aarch64-linux-gnu/libusb-1.0.so ./helios_dac/sdk/libusb-1.0.so
+
 ```
 
+Compile
 ```shell
 g++ -Wall -std=c++14 -fPIC -O2 -c HeliosDacAPI.cpp
 g++ -Wall -std=c++14 -fPIC -O2 -c HeliosDac.cpp


### PR DESCRIPTION
Fix path invalid at ubuntu 20.04 with RPi.

feedback of my case.