### PR TITLE
Fix USB teardown race on disconnect/reconnect

### DIFF
--- a/sdk/cpp/HeliosDac.cpp
+++ b/sdk/cpp/HeliosDac.cpp
@@ -861,8 +861,7 @@ HeliosDac::HeliosDacUsbDevice::HeliosDacUsbDevice(libusb_device_handle* handle)
 
 	closed = false;
 
-	std::thread frameHandlerThread(&HeliosDac::HeliosDacUsbDevice::BackgroundFrameHandler, this);
-	frameHandlerThread.detach();
+	frameHandlerThread = std::thread(&HeliosDac::HeliosDacUsbDevice::BackgroundFrameHandler, this);
 }
 
 // Sends a raw frame buffer (implemented as bulk transfer) to a dac device
@@ -872,7 +871,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrame(unsigned int pps, std::uint8_t flag
 	if (GetIsClosed())
 		return HELIOS_ERROR_DEVICE_CLOSED;
 
-	if (frameReady)
+	if (frameReady.load(std::memory_order_acquire))
 		return HELIOS_ERROR_DEVICE_FRAME_READY;
 
 	// If pps is too low, try to duplicate frames to simulate a higher pps rather than failing
@@ -963,8 +962,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrame(unsigned int pps, std::uint8_t flag
 
 	if ((flags & HELIOS_FLAGS_DONT_BLOCK) != 0)
 	{
-		threadingHasBeenUsed = true;
-		frameReady = true;
+		frameReady.store(true, std::memory_order_release);
 		return HELIOS_SUCCESS;
 	}
 	else
@@ -980,7 +978,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrameHighResolution(unsigned int pps, std
 	if (GetIsClosed())
 		return HELIOS_ERROR_DEVICE_CLOSED;
 
-	if (frameReady)
+	if (frameReady.load(std::memory_order_acquire))
 		return HELIOS_ERROR_DEVICE_FRAME_READY;
 
 	// If pps is too low, try to duplicate frames to simulate a higher pps rather than failing
@@ -1075,8 +1073,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrameHighResolution(unsigned int pps, std
 
 	if ((flags & HELIOS_FLAGS_DONT_BLOCK) != 0)
 	{
-		threadingHasBeenUsed = true;
-		frameReady = true;
+		frameReady.store(true, std::memory_order_release);
 		return HELIOS_SUCCESS;
 	}
 	else
@@ -1091,7 +1088,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrameExtended(unsigned int pps, std::uint
 	if (GetIsClosed())
 		return HELIOS_ERROR_DEVICE_CLOSED;
 
-	if (frameReady)
+	if (frameReady.load(std::memory_order_acquire))
 		return HELIOS_ERROR_DEVICE_FRAME_READY;
 
 	// If pps is too low, try to duplicate frames to simulate a higher pps rather than failing
@@ -1186,8 +1183,7 @@ int HeliosDac::HeliosDacUsbDevice::SendFrameExtended(unsigned int pps, std::uint
 
 	if ((flags & HELIOS_FLAGS_DONT_BLOCK) != 0)
 	{
-		threadingHasBeenUsed = true;
-		frameReady = true;
+		frameReady.store(true, std::memory_order_release);
 		return HELIOS_SUCCESS;
 	}
 	else
@@ -1199,6 +1195,10 @@ int HeliosDac::HeliosDacUsbDevice::SendFrameExtended(unsigned int pps, std::uint
 // Sends frame to DAC
 int HeliosDac::HeliosDacUsbDevice::DoFrame()
 {
+	if (GetIsClosed())
+		return HELIOS_ERROR_DEVICE_CLOSED;
+
+	std::lock_guard<std::mutex> lock(frameLock);
 	if (GetIsClosed())
 		return HELIOS_ERROR_DEVICE_CLOSED;
 
@@ -1224,11 +1224,8 @@ void HeliosDac::HeliosDacUsbDevice::BackgroundFrameHandler()
 {
 	while (!GetIsClosed())
 	{
-		while (!threadingHasBeenUsed)
-			plt_usleep(50000);
-
 		// Wait until frame is ready to be sent
-		while ((!frameReady) && (!GetIsClosed()))
+		while ((!frameReady.load(std::memory_order_acquire)) && (!GetIsClosed()))
 			plt_usleep(1000);
 
 		if (GetIsClosed())
@@ -1236,7 +1233,7 @@ void HeliosDac::HeliosDacUsbDevice::BackgroundFrameHandler()
 
 		DoFrame();
 
-		frameReady = false;
+		frameReady.store(false, std::memory_order_release);
 	}
 }
 
@@ -1402,9 +1399,14 @@ int HeliosDac::HeliosDacUsbDevice::Stop()
 
 int HeliosDac::HeliosDacUsbDevice::Close()
 {
+	if (GetIsClosed())
+		return HELIOS_SUCCESS;
+
 	Stop();
 	logInfo("Closing Helios USB DAC.\n");
-	closed = true;
+	closed.store(true, std::memory_order_release);
+	// Wake the background thread if it is waiting for frame-ready.
+	frameReady.store(true, std::memory_order_release);
 	return HELIOS_SUCCESS;
 }
 
@@ -1481,11 +1483,19 @@ int HeliosDac::HeliosDacUsbDevice::SendControl(std::uint8_t* bufferAddress, unsi
 
 HeliosDac::HeliosDacUsbDevice::~HeliosDacUsbDevice()
 {
-	closed = true;
-	std::lock_guard<std::mutex>lock(frameLock); //wait until all threads have closed
+	Close();
 
-	libusb_close(usbHandle);
-	delete frameBuffer;
+	if (frameHandlerThread.joinable())
+		frameHandlerThread.join();
+
+	std::lock_guard<std::mutex> lock(frameLock);
+	if (usbHandle != NULL)
+	{
+		libusb_close(usbHandle);
+		usbHandle = NULL;
+	}
+	delete[] frameBuffer;
+	frameBuffer = NULL;
 }
 
 

--- a/sdk/cpp/HeliosDac.h
+++ b/sdk/cpp/HeliosDac.h
@@ -32,6 +32,7 @@ Unless otherwise specified, functions return a negative error code on failure.
 #include <cstring>
 #include <cstdint>
 #include <thread>
+#include <atomic>
 #include <mutex>
 #include <vector>
 #include <memory>
@@ -300,9 +301,7 @@ private:
 	// Base class for individual DAC, for internal use
 	class HeliosDacDevice
 	{
-
 	public:
-
 		virtual ~HeliosDacDevice() {}
 
 		virtual int SendFrame(unsigned int pps, std::uint8_t flags, HeliosPoint* points, unsigned int numOfPoints) = 0;
@@ -319,18 +318,16 @@ private:
 		virtual int Close() = 0;
 		virtual int EraseFirmware() = 0;
 		virtual bool GetDidSendFrameRecently() = 0;
-		bool GetIsClosed() { return closed; }
+		bool GetIsClosed() { return closed.load(std::memory_order_acquire); }
 
 	protected:
-
-		bool closed = true;
+		std::atomic<bool> closed{true};
 	};
 
 	// Class for USB-connected Helios DACs, for internal use
 	class HeliosDacUsbDevice : public HeliosDacDevice
 	{
 	public:
-
 		HeliosDacUsbDevice(libusb_device_handle*);
 		~HeliosDacUsbDevice();
 
@@ -351,9 +348,7 @@ private:
 
 		libusb_device_handle* GetLibusbHandle();
 
-
 	private:
-
 		int DoFrame();
 		void BackgroundFrameHandler();
 		int SendControl(std::uint8_t* buffer, unsigned int bufferSize);
@@ -365,7 +360,8 @@ private:
 		struct libusb_transfer* interruptTransfer = NULL;
 		struct libusb_device_handle* usbHandle;
 		std::mutex frameLock;
-		bool frameReady = false;
+		std::thread frameHandlerThread;
+		std::atomic<bool> frameReady{false};
 		int firmwareVersion = 0;
 		char name[32] = { 0 };
 		std::uint8_t* frameBuffer;
@@ -376,7 +372,6 @@ private:
 		int minSampleRate = 7;
 		const int errorLimitResetValue = 50;
 		int errorLimitCountdown = errorLimitResetValue;
-		bool threadingHasBeenUsed = false;
 		uint64_t lastSendTime = 0;
 	};
 


### PR DESCRIPTION
## Summary
This attempts to fix a teardown race in the USB Helios path that can crash after unplug/replug while streaming. 

## Problem
When a USB Helios is disconnected and later reconnected, the process can crash in `libusb_bulk_transfer` from `HeliosDacUsbDevice::DoFrame()`.

## Root cause
`HeliosDacUsbDevice` started a detached background frame thread. During close/destruction, USB resources could be released while that thread was still running and attempting transfers.

## Changes
- Replace detached USB frame worker with a member `std::thread` and join it during teardown.
- Make teardown/frame-ready cross-thread state safe (`closed`, `frameReady` are atomic).
- Make `Close()` idempotent and wake the worker so it can exit promptly.
- In destructor: call `Close()`, join worker, then release `libusb` handle and frame buffer.
- Guard `DoFrame()` with `frameLock` before calling `libusb_bulk_transfer`.
- Fix frame buffer deletion to `delete[]`.
- Remove `threadingHasBeenUsed` gating and simplify worker wait logic to only `frameReady`/`closed`.

## Compatibility
- No public API changes.
- No protocol/data format changes.
- Behavior change is limited to lifecycle/thread-safety during disconnect/reconnect.
